### PR TITLE
Fix flake8 linting warnings for line breaks around binary operators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 127
 max-complexity = 10
-ignore = E501,W503
+ignore = E501,W503,W504
 exclude = .venv
 per-file-ignores = */tests/*:C901

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E127,E501
+ignore = E127,E501,W503,W504
 exclude = .venv,build,dist,*.egg-info

--- a/src/osdu_mcp_server/shared/auth_handler.py
+++ b/src/osdu_mcp_server/shared/auth_handler.py
@@ -188,15 +188,15 @@ class AuthHandler:
                     "Azure authentication token expired. Please run 'az login' to refresh"
                 )
             elif (
-                "invalid_scope" in error_message
-                or "scope format is invalid" in error_message
+                "invalid_scope" in error_message or
+                "scope format is invalid" in error_message
             ):
                 raise OSMCPAuthError(
                     "Invalid Azure client ID. Please verify your AZURE_CLIENT_ID is correct"
                 )
             elif (
-                "no accounts were found" in error_message
-                or "environment variables are not fully configured" in error_message
+                "no accounts were found" in error_message or
+                "environment variables are not fully configured" in error_message
             ):
                 if os.environ.get("AZURE_CLIENT_SECRET"):
                     raise OSMCPAuthError(

--- a/src/osdu_mcp_server/tools/schema/search.py
+++ b/src/osdu_mcp_server/tools/schema/search.py
@@ -273,23 +273,23 @@ async def _matches_text_search(
 
     # Check in identity fields
     if (
-        "id" in search_fields
-        and schema_identity.get("id", "").lower().find(text_lower) != -1
+        "id" in search_fields and
+        schema_identity.get("id", "").lower().find(text_lower) != -1
     ):
         return True
     if (
-        "authority" in search_fields
-        and schema_identity.get("authority", "").lower().find(text_lower) != -1
+        "authority" in search_fields and
+        schema_identity.get("authority", "").lower().find(text_lower) != -1
     ):
         return True
     if (
-        "source" in search_fields
-        and schema_identity.get("source", "").lower().find(text_lower) != -1
+        "source" in search_fields and
+        schema_identity.get("source", "").lower().find(text_lower) != -1
     ):
         return True
     if (
-        "entityType" in search_fields
-        and schema_identity.get("entityType", "").lower().find(text_lower) != -1
+        "entityType" in search_fields and
+        schema_identity.get("entityType", "").lower().find(text_lower) != -1
     ):
         return True
 
@@ -313,13 +313,13 @@ async def _matches_text_search(
 
         # Search in schema content fields
         if (
-            "title" in search_fields
-            and schema_content.get("title", "").lower().find(text_lower) != -1
+            "title" in search_fields and
+            schema_content.get("title", "").lower().find(text_lower) != -1
         ):
             return True
         if (
-            "description" in search_fields
-            and schema_content.get("description", "").lower().find(text_lower) != -1
+            "description" in search_fields and
+            schema_content.get("description", "").lower().find(text_lower) != -1
         ):
             return True
 


### PR DESCRIPTION
## Summary
This PR fixes flake8 W503 warnings about line breaks before binary operators and updates the configuration to handle the mutually exclusive W503/W504 warnings.

## Changes
- Fixed line break placement in  (2 occurrences)
- Fixed line break placement in  (6 occurrences)
- Added W504 to ignore list in  configuration
- Added both W503 and W504 to ignore list in 

## Context
W503 and W504 are mutually exclusive warnings:
- W503: line break before binary operator
- W504: line break after binary operator

Since the project was configured to ignore W503, we initially moved breaks to after operators, which triggered W504. The solution is to ignore both warnings to allow flexibility in code formatting.

## Testing
✅ Verified with 0 - returns 0 warnings

Closes #35