### PR TITLE
fix(github): Fix Copilot bot username case sensitivity in workflow

### DIFF
--- a/.github/workflows/copilot-assign.yml
+++ b/.github/workflows/copilot-assign.yml
@@ -26,7 +26,7 @@ jobs:
                 owner: owner,
                 repo: repo,
                 issue_number: issue_number,
-                assignees: ['copilot']
+                assignees: ['Copilot']
               });
               console.log('Successfully assigned issue to copilot user');
             } catch (error) {


### PR DESCRIPTION
## Summary
- Fixed case sensitivity issue with Copilot bot username in the auto-assign workflow
- Changed 'copilot' to 'Copilot' to match the actual bot username

## Problem
The copilot-assign workflow was failing to assign issues because it was using the wrong case for the Copilot bot username. GitHub usernames are case-sensitive, and the bot uses 'Copilot' with a capital C.

## Solution
Updated the assignees array to use the correct capitalization:
```diff
- assignees: ['copilot']
+ assignees: ['Copilot']
```

## Test Plan
- [x] Updated the workflow file
- [ ] Test by adding 'copilot' label to a new issue
- [ ] Verify the issue is assigned to the Copilot bot
- [ ] Confirm no errors in the workflow logs

Fixes #61

🤖 Generated with [Claude Code](https://claude.ai/code)