### PR TITLE
fix: add missing originator parameter to legaltag_create tool

### DIFF
--- a/src/osdu_mcp_server/resources/templates/legal-tag-template.json
+++ b/src/osdu_mcp_server/resources/templates/legal-tag-template.json
@@ -7,13 +7,14 @@
     "Modify description to reflect your specific use case",
     "All fields shown are required for successful creation"
   ],
-  "_example_mcp_call": "legaltag_create(name='public-usa-agent-test-20250619', description='Legal tag created by OSDU MCP Server AI agent for workflow testing', country_of_origin=['US'], contract_id='TEST-CONTRACT-001', security_classification='Public', personal_data='No Personal Data', export_classification='EAR99', data_type='Public Domain Data', expiration_date='2025-12-31')",
+  "_example_mcp_call": "legaltag_create(name='public-usa-agent-test-20250619', description='Legal tag created by OSDU MCP Server AI agent for workflow testing', country_of_origin=['US'], contract_id='TEST-CONTRACT-001', originator='OSDU-MCP-Server', security_classification='Public', personal_data='No Personal Data', export_classification='EAR99', data_type='Public Domain Data', expiration_date='2025-12-31')",
   
   "template": {
     "name": "public-usa-agent-test-YYYYMMDD",
     "description": "Legal tag created by OSDU MCP Server AI agent for workflow testing",
     "country_of_origin": ["US"],
-    "contract_id": "TEST-CONTRACT-001", 
+    "contract_id": "TEST-CONTRACT-001",
+    "originator": "OSDU-MCP-Server",
     "security_classification": "Public",
     "personal_data": "No Personal Data",
     "export_classification": "EAR99",
@@ -32,6 +33,7 @@
     "name": "Must be unique across partition. Include timestamp (YYYYMMDD) to ensure uniqueness",
     "country_of_origin": "Must be valid ISO country codes (e.g., 'US', 'GB', 'CA')",
     "contract_id": "Required field, use meaningful identifier for your organization",
+    "originator": "Required field (3-60 characters). Client or supplier name. Alphanumeric, spaces, hyphens, periods allowed",
     "expiration_date": "Must be future date in YYYY-MM-DD format",
     "description": "Should clearly indicate purpose and scope of data usage"
   },
@@ -39,7 +41,7 @@
   "common_errors": [
     "Name already exists: Use timestamp or UUID to ensure uniqueness",
     "Invalid country code: Use 2-letter ISO codes (US, not USA)",
-    "Missing originator: Some environments require 'originator' field",
+    "Invalid originator: Must be 3-60 characters, alphanumeric with spaces/hyphens/periods only",
     "Expired date: Must be in the future"
   ]
 }

--- a/src/osdu_mcp_server/tools/legal/create.py
+++ b/src/osdu_mcp_server/tools/legal/create.py
@@ -18,6 +18,7 @@ async def legaltag_create(
     description: str,
     country_of_origin: list[str],
     contract_id: str,
+    originator: str,
     security_classification: str,
     personal_data: str,
     export_classification: str,
@@ -32,6 +33,7 @@ async def legaltag_create(
         description: Tag description
         country_of_origin: ISO country codes
         contract_id: Associated contract ID
+        originator: Client or supplier name (3-60 characters, alphanumeric, spaces, hyphens, periods allowed)
         security_classification: Security level
         personal_data: Personal data type
         export_classification: Export classification control number
@@ -63,6 +65,7 @@ async def legaltag_create(
         properties = {
             "countryOfOrigin": country_of_origin,
             "contractId": contract_id,
+            "originator": originator,
             "securityClassification": security_classification,
             "personalData": personal_data,
             "exportClassification": export_classification,

--- a/tests/tools/legal/test_write_protection.py
+++ b/tests/tools/legal/test_write_protection.py
@@ -25,6 +25,7 @@ async def test_legaltag_create_write_disabled():
                 description="Test description",
                 country_of_origin=["US"],
                 contract_id="TEST123",
+                originator="Test-Company",
                 security_classification="Private",
                 personal_data="No Personal Data",
                 export_classification="EAR99",


### PR DESCRIPTION
## Summary

Fixes the missing `originator` parameter in the `legaltag_create` MCP tool to ensure full OSDU API compliance.

## Changes Made

- ✅ **Added originator parameter** to `legaltag_create` function signature
- ✅ **Updated properties construction** to include originator field in OSDU API request
- ✅ **Enhanced legal tag template** with originator field, validation notes, and updated examples
- ✅ **Updated test coverage** to include originator parameter in write protection tests
- ✅ **Fixed error messaging** to reflect that originator is now properly supported

## Technical Details

### Function Signature Update
```python
# Before
async def legaltag_create(
    name: str,
    description: str,
    country_of_origin: list[str],
    contract_id: str,
    security_classification: str,
    # ... other params
) -> dict:

# After  
async def legaltag_create(
    name: str,
    description: str,
    country_of_origin: list[str],
    contract_id: str,
    originator: str,  # ← NEW REQUIRED PARAMETER
    security_classification: str,
    # ... other params
) -> dict:
```

### Template Enhancement
Updated `legal-tag-template.json` with:
- Originator field in template structure
- Validation notes explaining 3-60 character requirement
- Updated example MCP call
- Fixed common error messaging

## Testing

- ✅ All legal service tests pass (7/7)
- ✅ Write protection tests updated and passing
- ✅ MyPy type checking passes
- ✅ Flake8 linting passes

## Validation

This fix addresses the exact issue identified in user testing:
- **Before**: Legal tag creation failed due to missing required originator field
- **After**: Legal tag creation now includes all required OSDU API fields

## Breaking Change Note

This is a **breaking change** for any existing code calling `legaltag_create`. The `originator` parameter is now required and must be provided.

**Migration**: Add `originator="YourCompanyName"` to all existing `legaltag_create` calls.

Closes #94