### PR TITLE
feat: Add custom OAuth scope support for v1.0 token OSDU environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ claude mcp add osdu-mcp-server uvx "git+https://github.com/danielscholl-osdu/osd
   - `AZURE_CLIENT_ID`: Service principal ID
   - `AZURE_CLIENT_SECRET`: Service principal secret  
   - `AZURE_TENANT_ID`: Your Azure tenant ID
+  - `OSDU_MCP_AUTH_SCOPE`: (Optional) Custom OAuth scope for v1.0 token environments
 
 **Claude Code CLI Example:**
 ```bash
@@ -174,6 +175,43 @@ claude mcp add osdu-mcp-server uvx "git+https://github.com/danielscholl-osdu/osd
   -e "AZURE_CLIENT_SECRET=your-service-principal-secret" \
   -e "AZURE_TENANT_ID=your-tenant-id"
 ```
+
+#### Method 3: v1.0 Token Authentication (Legacy OSDU Environments)
+
+For OSDU environments configured with v1.0 tokens (`"requestedAccessTokenVersion": 1` in app manifest):
+
+- **Setup**: Service principal with access to OSDU resource application
+- **Environment Variables**:
+  - `AZURE_CLIENT_ID`: Service principal ID (authentication app)
+  - `AZURE_CLIENT_SECRET`: Service principal secret
+  - `AZURE_TENANT_ID`: Your Azure tenant ID
+  - `OSDU_MCP_AUTH_SCOPE`: Target OSDU application ID with `/.default` suffix
+
+**Example Configuration:**
+```json
+{
+  "mcpServers": {
+    "osdu-mcp-server": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["git+https://github.com/danielscholl-osdu/osdu-mcp-server@main"],
+      "env": {
+        "OSDU_MCP_SERVER_URL": "https://your-osdu.com",
+        "OSDU_MCP_SERVER_DATA_PARTITION": "your-partition",
+        "AZURE_CLIENT_ID": "service-principal-id",
+        "AZURE_CLIENT_SECRET": "service-principal-secret",
+        "AZURE_TENANT_ID": "your-tenant-id",
+        "OSDU_MCP_AUTH_SCOPE": "osdu-resource-app-id/.default"
+      }
+    }
+  }
+}
+```
+
+**Use Cases:**
+- Legacy OSDU deployments with v1.0 token requirements
+- Environments where you authenticate with one app but request tokens for another
+- OSDU platforms with dedicated resource applications and specific JWT audience requirements
 
 #### Authorization Setup
 

--- a/src/osdu_mcp_server/shared/auth_handler.py
+++ b/src/osdu_mcp_server/shared/auth_handler.py
@@ -168,8 +168,12 @@ class AuthHandler:
                     "AZURE_CLIENT_ID environment variable is required for Azure authentication"
                 )
 
-            # Derive OAuth scope from client ID
-            scope = f"{client_id}/.default"
+            # Derive OAuth scope from client ID or custom scope
+            custom_scope = os.environ.get("OSDU_MCP_AUTH_SCOPE")
+            if custom_scope:
+                scope = custom_scope
+            else:
+                scope = f"{client_id}/.default"
 
             # Get new token
             self._cached_token = self._credential.get_token(scope)


### PR DESCRIPTION
## Summary
Add support for custom OAuth scopes to handle OSDU environments configured with v1.0 tokens and multi-application authentication patterns.

## Changes Made
• **Authentication Handler**: Added `OSDU_MCP_AUTH_SCOPE` environment variable support
• **README.md**: Added Method 3 for v1.0 Token Authentication with examples
• **ADR-011**: Updated status to "Superseded" with implementation notes

## Problem Solved
OSDU environments with v1.0 tokens (`"requestedAccessTokenVersion": 1`) require specific JWT audience claims that don't match the default `{CLIENT_ID}/.default` pattern. This change enables:

- Multi-application authentication (authenticate with service principal, request tokens for OSDU app)
- Legacy OSDU deployments with specific JWT audience requirements
- v1.0 token environments

## Testing
✅ Successfully tested with GLAB environment:
- All OSDU services now report "healthy" status
- Authentication working with custom scope configuration
- Backward compatibility verified

## Backward Compatibility
✅ Existing configurations continue to work without modification
✅ Default behavior unchanged when `OSDU_MCP_AUTH_SCOPE` not provided
✅ Custom scope only used when explicitly configured

Fixes #108

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>