### PR TITLE
fix(auth): request identity scopes for GCP ADC tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ claude mcp add osdu-mcp-server uvx "git+https://github.com/danielscholl-osdu/osd
   - `AZURE_CLIENT_ID`: Service principal ID
   - `AZURE_CLIENT_SECRET`: Service principal secret
   - `AZURE_TENANT_ID`: Your Azure tenant ID
-  - `OSDU_MCP_AUTH_SCOPE`: (Optional) Custom OAuth scope for v1.0 token environments
+  - `OSDU_MCP_AUTH_SCOPE`: (Optional) Custom OAuth scope for v1.0 token environments (see GCP Authentication for its GCP meaning)
 
 **Example:**
 ```bash
@@ -266,6 +266,20 @@ claude mcp add osdu-mcp-server uvx "git+https://github.com/danielscholl-osdu/osd
 - **Setup**: Configure Workload Identity on GKE
 - **Environment Variables**: None needed! Automatic credential discovery
 - **Note**: Works on GKE with Workload Identity configured
+
+**Scopes**
+
+All GCP methods request `cloud-platform` plus the identity scopes `openid` and `userinfo.email` by default. The identity scopes grant no additional access — they make the caller's email address present in the token, which OSDU requires to resolve entitlements. Without them every OSDU request fails with `401 Access denied`.
+
+- `OSDU_MCP_AUTH_SCOPE`: (Optional) Comma-separated list of scopes that replaces the defaults
+
+**Example:**
+```bash
+claude mcp add osdu-mcp-server uvx "git+https://github.com/danielscholl-osdu/osdu-mcp-server@main" \
+  -e "OSDU_MCP_SERVER_URL=https://your-osdu.com" \
+  -e "OSDU_MCP_SERVER_DATA_PARTITION=your-partition" \
+  -e "OSDU_MCP_AUTH_SCOPE=https://www.googleapis.com/auth/cloud-platform,openid,https://www.googleapis.com/auth/userinfo.email"
+```
 
 ---
 

--- a/docs/adr/029-multi-cloud-authentication.md
+++ b/docs/adr/029-multi-cloud-authentication.md
@@ -132,6 +132,24 @@ dependencies = [
 
 3. **Zero Tool Impact**: All 31 MCP tools continue to work without any changes
 
+### GCP Scope Selection
+
+GCP tokens are requested with three scopes by default:
+
+```python
+DEFAULT_GCP_SCOPES = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+]
+```
+
+`cloud-platform` alone is not sufficient. It is the broadest *access* scope, but it is not an *identity* scope, and `google.auth` narrows the minted token to exactly the scopes requested — the resulting token carries no `email` claim. OSDU resolves entitlements by the caller's email address, so such a token maps to no entitlement group and every OSDU service returns `401 Access denied`. This applies to both credential flows, service account key file and keyless ADC via the metadata server.
+
+The identity scopes grant no additional access; they only make the email claim present. An unscoped metadata token happens to include `userinfo.email` by default, which is why the problem only surfaces when an explicit narrow scope list is passed.
+
+`OSDU_MCP_AUTH_SCOPE` overrides the defaults with a comma-separated list, mirroring the Azure override established in [ADR-011](011-oauth-scope-simplification.md). On Azure the value is a single scope string; on GCP it is a list, because `google.auth.default()` takes a sequence.
+
 ### Token Acquisition Flow
 
 ```

--- a/specs/multi-cloud-auth-spec.md
+++ b/specs/multi-cloud-auth-spec.md
@@ -61,7 +61,7 @@ OSDU_MCP_SERVER_DATA_PARTITION # Data partition ID
 
 # Generic OAuth Token Override
 OSDU_MCP_USER_TOKEN          # Manual OAuth Bearer token (highest priority - overrides all)
-OSDU_MCP_AUTH_SCOPE          # Optional custom OAuth scope (for v1.0 Azure tokens)
+OSDU_MCP_AUTH_SCOPE          # Optional custom OAuth scope (v1.0 Azure tokens; comma-separated scope list on GCP)
 ```
 
 **Rationale:**
@@ -661,6 +661,7 @@ OSDU_MCP_SERVER_DATA_PARTITION # Required: Data partition ID
 # Authentication Configuration
 OSDU_MCP_USER_TOKEN          # Optional: Manual OAuth Bearer token (highest priority)
 OSDU_MCP_AUTH_SCOPE          # Optional: Custom OAuth scope for v1.0 Azure tokens
+                             #           On GCP: comma-separated scope list replacing the defaults
 
 # Security Configuration
 OSDU_MCP_ENABLE_WRITE_MODE   # Optional: Enable write operations (default: false)

--- a/src/osdu_mcp_server/shared/auth_handler.py
+++ b/src/osdu_mcp_server/shared/auth_handler.py
@@ -27,6 +27,15 @@ from .logging_manager import get_logger
 
 logger = get_logger(__name__)
 
+# OSDU authorizes by the caller's email address, which is only present in the
+# token when identity scopes are requested. cloud-platform alone yields a token
+# without an email claim, which OSDU rejects with 401.
+DEFAULT_GCP_SCOPES = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+]
+
 
 class AuthenticationMode(Enum):
     """Supported authentication modes."""
@@ -259,6 +268,9 @@ class AuthHandler:
         2. gcloud application-default credentials
         3. Compute Engine/GKE metadata service
 
+        Scopes default to DEFAULT_GCP_SCOPES and can be overridden with a
+        comma-separated OSDU_MCP_AUTH_SCOPE, mirroring the Azure behavior.
+
         Raises:
             OSMCPAuthError: If no GCP credentials found
         """
@@ -266,10 +278,13 @@ class AuthHandler:
             import google.auth
             from google.auth.exceptions import DefaultCredentialsError
 
-            # Get default credentials with cloud-platform scope
-            # This is the broadest GCP scope, equivalent to Azure's /.default
+            custom_scope = os.environ.get("OSDU_MCP_AUTH_SCOPE", "")
+            scopes = [
+                s.strip() for s in custom_scope.split(",") if s.strip()
+            ] or DEFAULT_GCP_SCOPES
+
             self._gcp_credentials, self._gcp_project = google.auth.default(
-                scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                scopes=scopes
             )
 
             logger.info(

--- a/tests/shared/test_auth_multicloud.py
+++ b/tests/shared/test_auth_multicloud.py
@@ -140,6 +140,110 @@ async def test_gcp_token_retrieval_with_refresh():
 
 
 @pytest.mark.asyncio
+async def test_gcp_requests_identity_scopes_by_default():
+    """Test GCP credentials request identity scopes so OSDU can resolve entitlements."""
+    mock_config = MagicMock(spec=ConfigManager)
+
+    with patch.dict(
+        os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "/path/to/key.json"}, clear=True
+    ):
+        with patch("google.auth.default") as mock_gcp:
+            mock_creds = MagicMock()
+            mock_creds.valid = True
+            mock_gcp.return_value = (mock_creds, "test-project")
+
+            AuthHandler(mock_config)
+
+            assert mock_gcp.call_args.kwargs["scopes"] == [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email",
+            ]
+
+
+@pytest.mark.asyncio
+async def test_gcp_custom_scope_replaces_defaults():
+    """Test OSDU_MCP_AUTH_SCOPE overrides the default GCP scopes."""
+    mock_config = MagicMock(spec=ConfigManager)
+
+    with patch.dict(
+        os.environ,
+        {
+            "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/key.json",
+            "OSDU_MCP_AUTH_SCOPE": "https://www.googleapis.com/auth/custom-scope",
+        },
+        clear=True,
+    ):
+        with patch("google.auth.default") as mock_gcp:
+            mock_creds = MagicMock()
+            mock_creds.valid = True
+            mock_gcp.return_value = (mock_creds, "test-project")
+
+            AuthHandler(mock_config)
+
+            assert mock_gcp.call_args.kwargs["scopes"] == [
+                "https://www.googleapis.com/auth/custom-scope"
+            ]
+
+
+@pytest.mark.asyncio
+async def test_gcp_custom_scope_parses_comma_separated_list():
+    """Test OSDU_MCP_AUTH_SCOPE accepts a comma-separated list with whitespace."""
+    mock_config = MagicMock(spec=ConfigManager)
+
+    with patch.dict(
+        os.environ,
+        {
+            "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/key.json",
+            "OSDU_MCP_AUTH_SCOPE": " openid , https://www.googleapis.com/auth/userinfo.email ",
+        },
+        clear=True,
+    ):
+        with patch("google.auth.default") as mock_gcp:
+            mock_creds = MagicMock()
+            mock_creds.valid = True
+            mock_gcp.return_value = (mock_creds, "test-project")
+
+            AuthHandler(mock_config)
+
+            assert mock_gcp.call_args.kwargs["scopes"] == [
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email",
+            ]
+
+
+@pytest.mark.asyncio
+async def test_azure_scope_unaffected_by_gcp_scope_handling():
+    """Test Azure still passes OSDU_MCP_AUTH_SCOPE through as a single scope string."""
+    mock_config = MagicMock(spec=ConfigManager)
+
+    with patch.dict(
+        os.environ,
+        {
+            "AZURE_CLIENT_ID": "azure-id",
+            "OSDU_MCP_AUTH_SCOPE": "api://azure-id/.default",
+        },
+        clear=True,
+    ):
+        with patch(
+            "osdu_mcp_server.shared.auth_handler.DefaultAzureCredential"
+        ) as mock_cred:
+            mock_cred_instance = MagicMock()
+            mock_cred_instance.get_token.return_value = AccessToken(
+                "azure-token", int(time.time()) + 3600
+            )
+            mock_cred.return_value = mock_cred_instance
+
+            auth = AuthHandler(mock_config)
+            token = await auth.get_access_token()
+
+            assert token == "azure-token"
+            mock_cred_instance.get_token.assert_called_once_with(
+                "api://azure-id/.default"
+            )
+
+
+@pytest.mark.asyncio
 async def test_gcp_credentials_not_found_error():
     """Test GCP credentials not found error message."""
     mock_config = MagicMock(spec=ConfigManager)

--- a/uv.lock
+++ b/uv.lock
@@ -156,21 +156,20 @@ wheels = [
 
 [[package]]
 name = "azure-core"
-version = "1.35.1"
+version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/6b/2653adc0f33adba8f11b1903701e6b1c10d34ce5d8e25dfa13a422f832b0/azure_core-1.35.1.tar.gz", hash = "sha256:435d05d6df0fff2f73fb3c15493bb4721ede14203f1ff1382aa6b6b2bdd7e562", size = 345290, upload-time = "2025-09-11T22:58:04.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/9b/23893febea484ad8183112c9419b5eb904773adb871492b5fa8ff7b21e09/azure_core-1.38.1.tar.gz", hash = "sha256:9317db1d838e39877eb94a2240ce92fa607db68adf821817b723f0d679facbf6", size = 363323, upload-time = "2026-02-11T02:03:06.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/52/805980aa1ba18282077c484dba634ef0ede1e84eec8be9c92b2e162d0ed6/azure_core-1.35.1-py3-none-any.whl", hash = "sha256:12da0c9e08e48e198f9158b56ddbe33b421477e1dc98c2e1c8f9e254d92c468b", size = 211800, upload-time = "2025-09-11T22:58:06.281Z" },
+    { url = "https://files.pythonhosted.org/packages/db/88/aaea2ad269ce70b446660371286272c1f6ba66541a7f6f635baf8b0db726/azure_core-1.38.1-py3-none-any.whl", hash = "sha256:69f08ee3d55136071b7100de5b198994fc1c5f89d2b91f2f43156d20fcf200a4", size = 217930, upload-time = "2026-02-11T02:03:07.548Z" },
 ]
 
 [[package]]
 name = "azure-identity"
-version = "1.25.1"
+version = "1.25.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -179,9 +178,9 @@ dependencies = [
     { name = "msal-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8d/1a6c41c28a37eab26dc85ab6c86992c700cd3f4a597d9ed174b0e9c69489/azure_identity-1.25.1.tar.gz", hash = "sha256:87ca8328883de6036443e1c37b40e8dc8fb74898240f61071e09d2e369361456", size = 279826, upload-time = "2025-10-06T20:30:02.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/3a/439a32a5e23e45f6a91f0405949dc66cfe6834aba15a430aebfc063a81e7/azure_identity-1.25.2.tar.gz", hash = "sha256:030dbaa720266c796221c6cdbd1999b408c079032c919fef725fcc348a540fe9", size = 284709, upload-time = "2026-02-11T01:55:42.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/5652771e24fff12da9dde4c20ecf4682e606b104f26419d139758cc935a6/azure_identity-1.25.1-py3-none-any.whl", hash = "sha256:e9edd720af03dff020223cd269fa3a61e8f345ea75443858273bcb44844ab651", size = 191317, upload-time = "2025-10-06T20:30:04.251Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/77/f658c76f9e9a52c784bd836aaca6fd5b9aae176f1f53273e758a2bcda695/azure_identity-1.25.2-py3-none-any.whl", hash = "sha256:1b40060553d01a72ba0d708b9a46d0f61f56312e215d8896d836653ffdc6753d", size = 191423, upload-time = "2026-02-11T01:55:44.245Z" },
 ]
 
 [[package]]
@@ -845,8 +844,8 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.0" },
     { name = "aioresponses", marker = "extra == 'dev'", specifier = ">=0.7.8" },
-    { name = "azure-core", specifier = "==1.35.1" },
-    { name = "azure-identity", specifier = "==1.25.1" },
+    { name = "azure-core", specifier = "==1.38.1" },
+    { name = "azure-identity", specifier = "==1.25.2" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.9.0" },
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.3.0" },


### PR DESCRIPTION
## Description

Re-land of #129 by @Alrem on an in-repo branch. The commit (`f0f460e`) is pushed unchanged, so authorship is preserved; only the branch location differs.

GCP mode requested only `https://www.googleapis.com/auth/cloud-platform`. That is the broadest *access* scope but not an *identity* scope, and `google.auth` narrows the minted token to exactly the scopes requested — so the token carried no `email` claim. OSDU resolves entitlements by the caller's email address, so the caller mapped to no entitlement group and every service returned `401 Access denied`. This affected both credential flows (service account key file and keyless ADC via the metadata server).

The change adds `openid` and `userinfo.email` to the GCP defaults (they grant no additional access, only the email claim) and honours `OSDU_MCP_AUTH_SCOPE` as a comma-separated override, mirroring the existing Azure behaviour from ADR-011. Azure and AWS code paths are untouched.

**Why re-landed here:** #129 was permanently blocked. The branch ruleset requires CodeQL code-scanning results, but CodeQL's default setup posts no check at all on pull requests from forks — so the rule is unsatisfiable for any external contribution. Opening from an in-repo branch lets the required check post normally instead of bypassing branch protection.

## Related Issues

Closes #128
Supersedes #129

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code builds and passes tests
- [x] Documentation updated
- [x] Conventional commit format used
- [ ] Reviewer assigned

## Additional Notes

Verified locally at `f0f460e`:

- `black --check src/ tests/` — 102 files unchanged
- `flake8 src/ --count` — 0
- `mypy src/osdu_mcp_server` — no issues in 62 source files
- `pytest` — 183 passed, coverage 73.09% (above the 70% gate)

Four `tests/shared/test_config.py` failures reproduce identically on `main` and are environmental: the tests don't clear `OSDU_MCP_*` from the environment, so they fail on any machine with the MCP server configured. Unrelated to this change; fixed separately.

This commit also refreshes `uv.lock`, which had drifted from `pyproject.toml` on main (lock at azure-core 1.35.1 / azure-identity 1.25.1 vs pyproject's 1.38.1 / 1.25.2 after `0ea8af5`). The lock now matches.