### PR TITLE
ci: detect lock drift, fix codecov input, isolate config tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         
     - name: Install dependencies
       run: |
-        uv sync --frozen
+        uv sync --locked
         uv pip install -e .[dev]
         
     # Run all quality checks - continue on error to see all failures
@@ -136,5 +136,5 @@ jobs:
       if: matrix.python-version == '3.12'  # Only upload once
       continue-on-error: true  # Don't fail if service is down
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false

--- a/tests/shared/test_config.py
+++ b/tests/shared/test_config.py
@@ -27,6 +27,7 @@ server:
     with (
         patch("builtins.open", mock_open(read_data=yaml_content)),
         patch("pathlib.Path.exists", return_value=True),
+        patch.dict(os.environ, {}, clear=True),
     ):
         config = ConfigManager()
         assert config.get("server", "url") == "https://yaml-osdu.com"
@@ -41,7 +42,10 @@ def test_config_manager_default_fallback():
 
 def test_config_manager_required_missing():
     """Test that get_required raises error for missing values."""
-    with patch("pathlib.Path.exists", return_value=False):
+    with (
+        patch("pathlib.Path.exists", return_value=False),
+        patch.dict(os.environ, {}, clear=True),
+    ):
         config = ConfigManager()
         with pytest.raises(OSMCPConfigError) as exc_info:
             config.get_required("server", "url")
@@ -104,7 +108,7 @@ auth:
     with (
         patch("builtins.open", mock_open(read_data=yaml_content)),
         patch("pathlib.Path.exists", return_value=True),
-        patch.dict(os.environ, {"OSDU_MCP_SERVER_TIMEOUT": "30"}),
+        patch.dict(os.environ, {"OSDU_MCP_SERVER_TIMEOUT": "30"}, clear=True),
     ):
 
         config = ConfigManager()
@@ -125,6 +129,7 @@ server:
     with (
         patch("builtins.open", mock_open(read_data=yaml_content)),
         patch("pathlib.Path.exists", return_value=True),
+        patch.dict(os.environ, {}, clear=True),
     ):
 
         config = ConfigManager(config_file=custom_path)


### PR DESCRIPTION
## Description

Three CI/test hygiene defects found while clearing the open PR backlog.

**CI could not detect `pyproject.toml`/`uv.lock` drift.** The install step used `uv sync --frozen`, which installs from the lock as-is and never compares it to `pyproject.toml`. The two silently diverged after `0ea8af5` bumped pyproject to azure-core 1.38.1 / azure-identity 1.25.2 without regenerating the lock, which stayed at 1.35.1 / 1.25.1 — so every CI run since then was green while testing the *older* versions, and the bump was inert. Switching to `uv sync --locked` makes CI fail fast when they disagree.

**The codecov step passed a non-existent input.** `file:` is not defined by codecov-action v5 or v6 — the input is `files:`. It was silently ignored, and upload fell back to auto-discovery. Because the step is `continue-on-error` with `fail_ci_if_error: false`, this never surfaced.

**Four config tests failed on any machine running the MCP server.** `ConfigManager` reads environment first by design (ADR-003), but these tests asserted on YAML and default values without clearing the environment, so a real `OSDU_MCP_SERVER_URL` overrode the fixture. They passed in CI only because CI has a clean environment. Fixed with `patch.dict(os.environ, {}, clear=True)`, matching the ADR-010 guidance on patching environment boundaries.

## Related Issues

Closes #131

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code builds and passes tests
- [ ] Documentation updated
- [x] Conventional commit format used
- [ ] Reviewer assigned

## Additional Notes

The drift this guards against was real and had already shipped — it was caught only incidentally, when an external contributor's unrelated `uv sync` regenerated the lock as a side effect of #129.

Verified locally with `OSDU_MCP_*` variables **present** in the environment, which is the condition that previously failed:

- `pytest` — 187 passed (was 183 passed / 4 failed)
- `uv sync --locked` — succeeds against current `main`
- `black --check` — clean
- `flake8 src/ --count` — 0

Touches only `.github/**` and `tests/**`, both in the release-please `exclude-paths`, so no version bump is triggered.